### PR TITLE
Simplify "DecodedMappings" interface

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -11,16 +11,14 @@ import { DecodedSourceMap, DecodedMappings } from "./interfaces";
       sources: [],
       sourcesContent: [],
       names: [],
-      mappings: {
-        lines: [
-          [{
-            col: <position in output line>,
-            src: <position in sources array>,
-            srcLine: <line within source>,
-            srcCol: <column within source line>,
-          }]
-        ],
-      },
+      mappings: [
+        [{
+          col: <position in output line>,
+          src: <position in sources array>,
+          srcLine: <line within source>,
+          srcCol: <column within source line>,
+        }]
+      ],
       file:
     }
   ```
@@ -39,7 +37,7 @@ export default function concat(maps: DecodedSourceMap[]): DecodedSourceMap {
 
   let offset = 0;
   let mappings = maps.reduce((acc: DecodedMappings, map) => {
-    acc.lines = acc.lines.concat(map.mappings.lines.map(lineMappings => {
+    acc = acc.concat(map.mappings.map(lineMappings => {
       return lineMappings.map(mapping => ({
         fieldCount: mapping.fieldCount,
         col: mapping.col,
@@ -52,7 +50,7 @@ export default function concat(maps: DecodedSourceMap[]): DecodedSourceMap {
     offset += map.sources.length;
 
     return acc;
-  }, { lines: [] });
+  }, []);
 
   return {
     version: "3",

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -12,14 +12,14 @@ import { DecodedSourceMap, DecodedMappings } from "./interfaces";
       sourcesContent: [],
       names: [],
       mappings: {
-        lines: [{
-          mappings: [{
+        lines: [
+          [{
             col: <position in output line>,
             src: <position in sources array>,
             srcLine: <line within source>,
             srcCol: <column within source line>,
           }]
-        }],
+        ],
       },
       file:
     }
@@ -40,17 +40,13 @@ export default function concat(maps: DecodedSourceMap[]): DecodedSourceMap {
   let offset = 0;
   let mappings = maps.reduce((acc: DecodedMappings, map) => {
     acc.lines = acc.lines.concat(map.mappings.lines.map(lineMappings => {
-      let transformedLineMappings = lineMappings.mappings.map(mapping => ({
+      return lineMappings.map(mapping => ({
         fieldCount: mapping.fieldCount,
         col: mapping.col,
         src: mapping.src + offset,
         srcLine: mapping.srcLine,
         srcCol: mapping.srcCol,
       }));
-
-      return {
-        mappings: transformedLineMappings,
-      };
     }));
 
     offset += map.sources.length;

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -4,13 +4,11 @@ import { FullDecodedMapping, DecodedMappings } from "./interfaces";
 export default class Decoder implements Delegate {
   currentLine: Array<FullDecodedMapping> = [];
 
-  mappings: DecodedMappings = {
-    lines: [this.currentLine],
-  };
+  mappings: DecodedMappings = [this.currentLine];
 
   newline() {
     this.currentLine = [];
-    this.mappings.lines.push(this.currentLine);
+    this.mappings.push(this.currentLine);
   }
 
   mapping1(col) {

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -5,14 +5,12 @@ export default class Decoder implements Delegate {
   currentLine: Array<FullDecodedMapping> = [];
 
   mappings: DecodedMappings = {
-    lines: [{
-      mappings: this.currentLine,
-    }],
+    lines: [this.currentLine],
   };
 
   newline() {
     this.currentLine = [];
-    this.mappings.lines.push({ mappings: this.currentLine });
+    this.mappings.lines.push(this.currentLine);
   }
 
   mapping1(col) {

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,5 +1,6 @@
 import { Delegate } from "./mappings-decoder";
 import { FullDecodedMapping, DecodedMappings } from "./interfaces";
+import { createMapping1, createMapping4, createMapping5 } from "./mapping-factories";
 
 export default class Decoder implements Delegate {
   currentLine: Array<FullDecodedMapping> = [];
@@ -12,35 +13,14 @@ export default class Decoder implements Delegate {
   }
 
   mapping1(col) {
-    this.currentLine.push({
-      fieldCount: 1,
-      col,
-      src: 0,
-      srcLine: 0,
-      srcCol: 0,
-      name: 0,
-    });
+    this.currentLine.push(createMapping1(col));
   }
 
   mapping4(col, src, srcLine, srcCol) {
-    this.currentLine.push({
-      fieldCount: 4,
-      col,
-      src,
-      srcLine,
-      srcCol,
-      name: 0,
-    });
+    this.currentLine.push(createMapping4(col, src, srcLine, srcCol));
   }
 
   mapping5(col, src, srcLine, srcCol, name) {
-    this.currentLine.push({
-      fieldCount: 5,
-      col,
-      src,
-      srcLine,
-      srcCol,
-      name,
-    });
+    this.currentLine.push(createMapping5(col, src, srcLine, srcCol, name));
   }
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,12 +16,8 @@ export interface FullDecodedMapping extends DecodedMapping {
 
 export type LineMappings = Array<DecodedMapping>
 
-export interface LineDescriptor {
-  mappings: LineMappings;
-}
-
 export interface DecodedMappings {
-  lines: Array<LineDescriptor>;
+  lines: Array<LineMappings>;
 }
 
 export interface DecodedSourceMap {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,9 +16,7 @@ export interface FullDecodedMapping extends DecodedMapping {
 
 export type LineMappings = Array<DecodedMapping>
 
-export interface DecodedMappings {
-  lines: Array<LineMappings>;
-}
+export type DecodedMappings = Array<LineMappings>
 
 export interface DecodedSourceMap {
   version: string;

--- a/src/mapping-factories.ts
+++ b/src/mapping-factories.ts
@@ -1,0 +1,34 @@
+import { FullDecodedMapping } from "./interfaces";
+
+export function createMapping1(col): FullDecodedMapping {
+  return {
+    fieldCount: 1,
+    col,
+    src: 0,
+    srcLine: 0,
+    srcCol: 0,
+    name: 0,
+  };
+}
+
+export function createMapping4(col, src, srcLine, srcCol): FullDecodedMapping {
+  return {
+    fieldCount: 4,
+    col,
+    src,
+    srcLine,
+    srcCol,
+    name: 0,
+  };
+}
+
+export function createMapping5(col, src, srcLine, srcCol, name): FullDecodedMapping {
+  return {
+    fieldCount: 5,
+    col,
+    src,
+    srcLine,
+    srcCol,
+    name,
+  };
+}

--- a/src/mappings-encoder.ts
+++ b/src/mappings-encoder.ts
@@ -23,8 +23,8 @@ export default class MappingsEncoder {
   }
 
   encode(mappings: DecodedMappings) {
-    for (let i = 0; i < mappings.lines.length; i++) {
-      let line = mappings.lines[i];
+    for (let i = 0; i < mappings.length; i++) {
+      let line = mappings[i];
 
       for (let j = 0; j < line.length; j++) {
         let mapping = line[j];
@@ -49,7 +49,7 @@ export default class MappingsEncoder {
         }
       }
 
-      if (i < mappings.lines.length - 1 ) {
+      if (i < mappings.length - 1 ) {
         // skip trailing line separator
         this.newline();
       }

--- a/src/mappings-encoder.ts
+++ b/src/mappings-encoder.ts
@@ -26,8 +26,8 @@ export default class MappingsEncoder {
     for (let i = 0; i < mappings.lines.length; i++) {
       let line = mappings.lines[i];
 
-      for (let j = 0; j < line.mappings.length; j++) {
-        let mapping = line.mappings[j];
+      for (let j = 0; j < line.length; j++) {
+        let mapping = line[j];
 
         switch (mapping.fieldCount) {
           case 1:
@@ -43,7 +43,7 @@ export default class MappingsEncoder {
             missingFieldCount();
         }
 
-        if (j < line.mappings.length - 1) {
+        if (j < line.length - 1) {
           // no trailing segment separator
           this.separator();
         }

--- a/src/tests/concat-tests.ts
+++ b/src/tests/concat-tests.ts
@@ -14,7 +14,7 @@ describe("concat()", function() {
       sources: [],
       sourcesContent: [],
       names: [],
-      mappings: { lines: [] },
+      mappings: [],
       file: "",
     }, "concatenator can output the empty case");
   });
@@ -25,17 +25,13 @@ describe("concat()", function() {
       sources: [ "file1.js" ],
       sourcesContent: [],
       names: [],
-      mappings: {
-        lines: [
-          [ {
-            fieldCount: 4,
-            col: 0,
-            src: 0,
-            srcLine: 1,
-            srcCol: 0,
-          } ],
-        ],
-      },
+      mappings: [[{
+        fieldCount: 4,
+        col: 0,
+        src: 0,
+        srcLine: 1,
+        srcCol: 0,
+      }]],
       file: "map1.js",
     };
 
@@ -44,17 +40,13 @@ describe("concat()", function() {
       sources: [ "file1.js" ],
       sourcesContent: [],
       names: [],
-      mappings: {
-        lines: [ 
-          [ {
-            fieldCount: 4,
-            col: 0,
-            src: 0,
-            srcLine: 1,
-            srcCol: 0,
-          } ],
-        ],
-      },
+      mappings: [[{
+        fieldCount: 4,
+        col: 0,
+        src: 0,
+        srcLine: 1,
+        srcCol: 0,
+      }]],
       file: "",
     }, "concatenator can output a single source map");
   });

--- a/src/tests/concat-tests.ts
+++ b/src/tests/concat-tests.ts
@@ -26,15 +26,15 @@ describe("concat()", function() {
       sourcesContent: [],
       names: [],
       mappings: {
-        lines: [ {
-          mappings: [ {
+        lines: [
+          [ {
             fieldCount: 4,
             col: 0,
             src: 0,
             srcLine: 1,
             srcCol: 0,
           } ],
-        } ],
+        ],
       },
       file: "map1.js",
     };
@@ -45,15 +45,15 @@ describe("concat()", function() {
       sourcesContent: [],
       names: [],
       mappings: {
-        lines: [ {
-          mappings: [ {
+        lines: [ 
+          [ {
             fieldCount: 4,
             col: 0,
             src: 0,
             srcLine: 1,
             srcCol: 0,
           } ],
-        } ],
+        ],
       },
       file: "",
     }, "concatenator can output a single source map");

--- a/src/tests/encoder-tests.ts
+++ b/src/tests/encoder-tests.ts
@@ -82,8 +82,8 @@ describe("Encoder", function() {
       expect(encoder.writes).to.deep.equal([]);
 
       mapper.encode({
-        lines: [ {
-          mappings: [ {
+        lines: [
+          [ {
             fieldCount: 1,
             col: 105,
             src: 0,
@@ -105,7 +105,7 @@ describe("Encoder", function() {
             srcCol: 0,
             name: 0
           } ],
-        } ],
+        ],
       });
 
       expect(encoder.writes).to.deep.equal([ 105, ",", 95, ",", 100 ]);
@@ -115,8 +115,8 @@ describe("Encoder", function() {
       expect(encoder.writes).to.deep.equal([]);
 
       mapper.encode({
-        lines: [ {
-          mappings: [ {
+        lines: [
+          [ {
             fieldCount: 5,
             col: 10,
             src: 11,
@@ -138,7 +138,7 @@ describe("Encoder", function() {
             srcCol: 33,
             name: 0
           } ],
-        } ],
+        ],
       });
 
       expect(encoder.writes).to.deep.equal([
@@ -152,8 +152,8 @@ describe("Encoder", function() {
       expect(encoder.writes).to.deep.equal([]);
 
       mapper.encode({
-        lines: [ {
-          mappings: [ {
+        lines: [
+          [ {
             fieldCount: 1,
             col: 10,
             src: 0,
@@ -163,9 +163,7 @@ describe("Encoder", function() {
           }, {
             fieldCount: 1,
             col: 20,
-          } ],
-        }, {
-          mappings: [ {
+          } ], [ {
             fieldCount: 1,
             col: 100,
             src: 0,
@@ -173,7 +171,7 @@ describe("Encoder", function() {
             srcCol: 0,
             name: 0
           } ],
-        } ],
+        ],
       });
 
       expect(encoder.writes).to.deep.equal([
@@ -186,8 +184,8 @@ describe("Encoder", function() {
       expect(encoder.writes).to.deep.equal([]);
 
       mapper.encode({
-        lines: [ {
-          mappings: [ {
+        lines: [
+          [ {
             fieldCount: 1,
             col: 10,
             src: 0,
@@ -202,8 +200,7 @@ describe("Encoder", function() {
             srcCol: 0,
             name: 0
           } ],
-        }, {
-          mappings: [ {
+          [ {
             fieldCount: 5,
             col: 100,
             src: 101,
@@ -211,8 +208,7 @@ describe("Encoder", function() {
             srcCol: 103,
             name: 104,
           } ],
-        }, {
-          mappings: [ {
+          [ {
             fieldCount: 4,
             col: 200,
             src: 201,
@@ -227,7 +223,7 @@ describe("Encoder", function() {
             srcCol: 303,
             name: 0
           } ],
-        } ],
+        ],
       });
 
       expect(encoder.writes).to.deep.equal([

--- a/src/tests/encoder-tests.ts
+++ b/src/tests/encoder-tests.ts
@@ -81,32 +81,28 @@ describe("Encoder", function() {
     it("encodes sequences of the same field length", function() {
       expect(encoder.writes).to.deep.equal([]);
 
-      mapper.encode({
-        lines: [
-          [ {
-            fieldCount: 1,
-            col: 105,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          }, {
-            fieldCount: 1,
-            col: 200,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          }, {
-            fieldCount: 1,
-            col: 300,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          } ],
-        ],
-      });
+      mapper.encode([[{
+        fieldCount: 1,
+        col: 105,
+        src: 0,
+        srcLine: 0,
+        srcCol: 0,
+        name: 0
+      }, {
+        fieldCount: 1,
+        col: 200,
+        src: 0,
+        srcLine: 0,
+        srcCol: 0,
+        name: 0
+      }, {
+        fieldCount: 1,
+        col: 300,
+        src: 0,
+        srcLine: 0,
+        srcCol: 0,
+        name: 0
+      }]]);
 
       expect(encoder.writes).to.deep.equal([ 105, ",", 95, ",", 100 ]);
     });
@@ -114,32 +110,28 @@ describe("Encoder", function() {
     it("encodes sequences of mixed field lengths", function() {
       expect(encoder.writes).to.deep.equal([]);
 
-      mapper.encode({
-        lines: [
-          [ {
-            fieldCount: 5,
-            col: 10,
-            src: 11,
-            srcLine: 12,
-            srcCol: 13,
-            name: 14,
-          }, {
-            fieldCount: 1,
-            col: 20,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          }, {
-            fieldCount: 4,
-            col: 30,
-            src: 31,
-            srcLine: 32,
-            srcCol: 33,
-            name: 0
-          } ],
-        ],
-      });
+      mapper.encode([[{
+        fieldCount: 5,
+        col: 10,
+        src: 11,
+        srcLine: 12,
+        srcCol: 13,
+        name: 14,
+      }, {
+        fieldCount: 1,
+        col: 20,
+        src: 0,
+        srcLine: 0,
+        srcCol: 0,
+        name: 0
+      }, {
+        fieldCount: 4,
+        col: 30,
+        src: 31,
+        srcLine: 32,
+        srcCol: 33,
+        name: 0
+      }]]);
 
       expect(encoder.writes).to.deep.equal([
         10, 11, 12, 13, 14, ",",
@@ -151,28 +143,28 @@ describe("Encoder", function() {
     it("encodes multiple lines with single segments", function() {
       expect(encoder.writes).to.deep.equal([]);
 
-      mapper.encode({
-        lines: [
-          [ {
-            fieldCount: 1,
-            col: 10,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          }, {
-            fieldCount: 1,
-            col: 20,
-          } ], [ {
-            fieldCount: 1,
-            col: 100,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          } ],
-        ],
-      });
+      mapper.encode([[
+        {
+          fieldCount: 1,
+          col: 10,
+          src: 0,
+          srcLine: 0,
+          srcCol: 0,
+          name: 0
+        }, {
+          fieldCount: 1,
+          col: 20,
+        }
+      ], [
+        {
+          fieldCount: 1,
+          col: 100,
+          src: 0,
+          srcLine: 0,
+          srcCol: 0,
+          name: 0
+        }
+      ]]);
 
       expect(encoder.writes).to.deep.equal([
         10, ",", 10, ";",
@@ -183,48 +175,48 @@ describe("Encoder", function() {
     it("encodes multiple lines with multiple mixed segments", function() {
       expect(encoder.writes).to.deep.equal([]);
 
-      mapper.encode({
-        lines: [
-          [ {
-            fieldCount: 1,
-            col: 10,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          }, {
-            fieldCount: 1,
-            col: 20,
-            src: 0,
-            srcLine: 0,
-            srcCol: 0,
-            name: 0
-          } ],
-          [ {
-            fieldCount: 5,
-            col: 100,
-            src: 101,
-            srcLine: 102,
-            srcCol: 103,
-            name: 104,
-          } ],
-          [ {
-            fieldCount: 4,
-            col: 200,
-            src: 201,
-            srcLine: 202,
-            srcCol: 203,
-            name: 0
-          }, {
-            fieldCount: 4,
-            col: 300,
-            src: 301,
-            srcLine: 302,
-            srcCol: 303,
-            name: 0
-          } ],
-        ],
-      });
+      mapper.encode([[
+        {
+          fieldCount: 1,
+          col: 10,
+          src: 0,
+          srcLine: 0,
+          srcCol: 0,
+          name: 0
+        }, {
+          fieldCount: 1,
+          col: 20,
+          src: 0,
+          srcLine: 0,
+          srcCol: 0,
+          name: 0
+        }
+      ], [
+        {
+          fieldCount: 5,
+          col: 100,
+          src: 101,
+          srcLine: 102,
+          srcCol: 103,
+          name: 104,
+        }
+      ], [
+        {
+          fieldCount: 4,
+          col: 200,
+          src: 201,
+          srcLine: 202,
+          srcCol: 203,
+          name: 0
+        }, {
+          fieldCount: 4,
+          col: 300,
+          src: 301,
+          srcLine: 302,
+          srcCol: 303,
+          name: 0
+        }
+      ]]);
 
       expect(encoder.writes).to.deep.equal([
         10, ",", 10, ";",

--- a/src/tests/fixtures/map1-2.ts
+++ b/src/tests/fixtures/map1-2.ts
@@ -9,101 +9,99 @@ export default {
     "function somethingElse() {\n  throw new Error(\"somethign else\");\n}\n",
   ],
   names: [],
-  mappings: {
-    "lines": [
-      // first.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 3,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 4,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 5,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 6,
-          "srcCol": 0,
-        },
-      ],
-      // second.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
+  mappings: [
+    // first.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
     ],
-  },
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 3,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 4,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 5,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 6,
+        "srcCol": 0,
+      },
+    ],
+    // second.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+  ],
   file: "",
 };

--- a/src/tests/fixtures/map1-2.ts
+++ b/src/tests/fixtures/map1-2.ts
@@ -12,117 +12,97 @@ export default {
   mappings: {
     "lines": [
       // first.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 3,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 4,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 5,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 6,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 3,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 4,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 5,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 6,
+          "srcCol": 0,
+        },
+      ],
       // second.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
     ],
   },
   file: "",

--- a/src/tests/fixtures/map1.ts
+++ b/src/tests/fixtures/map1.ts
@@ -7,83 +7,69 @@ export default {
   names: [],
   mappings: {
     "lines": [
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 3,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 4,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 5,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 6,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 3,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 4,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 5,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 6,
+          "srcCol": 0,
+        },
+      ],
     ],
   },
   file: "map1.js",

--- a/src/tests/fixtures/map1.ts
+++ b/src/tests/fixtures/map1.ts
@@ -5,72 +5,70 @@ export default {
     "function meaningOfLife() {\n  throw new Error(42);\n}\n\nfunction boom() {\n  throw new Error('boom');\n}\n",
   ],
   names: [],
-  mappings: {
-    "lines": [
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 3,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 4,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 5,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 6,
-          "srcCol": 0,
-        },
-      ],
+  mappings: [
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
     ],
-  },
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 3,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 4,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 5,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 6,
+        "srcCol": 0,
+      },
+    ],
+  ],
   file: "map1.js",
 };

--- a/src/tests/fixtures/map2.ts
+++ b/src/tests/fixtures/map2.ts
@@ -7,36 +7,34 @@ export default {
     "function somethingElse() {\n  throw new Error(\"somethign else\");\n}\n",
   ],
   names: [],
-  mappings: {
-    "lines": [
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
+  mappings: [
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
     ],
-  },
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+  ],
   file: "map2.js",
 };

--- a/src/tests/fixtures/map2.ts
+++ b/src/tests/fixtures/map2.ts
@@ -9,39 +9,33 @@ export default {
   names: [],
   mappings: {
     "lines": [
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
     ],
   },
   file: "map2.js",

--- a/src/tests/fixtures/map3-4-1.ts
+++ b/src/tests/fixtures/map3-4-1.ts
@@ -11,165 +11,163 @@ export default {
     "function meaningOfLife() {\n  throw new Error(42);\n}\n\nfunction boom() {\n  throw new Error('boom');\n}\n",
   ],
   names: [],
-  mappings: {
-    "lines": [
-      // third.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 3,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 4,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 5,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 6,
-          "srcCol": 0,
-        },
-      ],
-      // fourth.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      // first.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 3,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 4,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 5,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 2,
-          "srcLine": 6,
-          "srcCol": 0,
-        },
-      ],
+  mappings: [
+    // third.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
     ],
-  },
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 3,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 4,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 5,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 6,
+        "srcCol": 0,
+      },
+    ],
+    // fourth.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    // first.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 3,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 4,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 5,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 2,
+        "srcLine": 6,
+        "srcCol": 0,
+      },
+    ],
+  ],
   file: "",
 };

--- a/src/tests/fixtures/map3-4-1.ts
+++ b/src/tests/fixtures/map3-4-1.ts
@@ -14,195 +14,161 @@ export default {
   mappings: {
     "lines": [
       // third.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 3,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 4,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 5,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 6,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 3,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 4,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 5,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 6,
+          "srcCol": 0,
+        },
+      ],
       // fourth.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
       // first.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 3,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 4,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 5,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 2,
-            "srcLine": 6,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 3,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 4,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 5,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 2,
+          "srcLine": 6,
+          "srcCol": 0,
+        },
+      ],
     ],
   },
   file: "",

--- a/src/tests/fixtures/map3-4.ts
+++ b/src/tests/fixtures/map3-4.ts
@@ -9,101 +9,99 @@ export default {
     "function somethingElse() {\n  throw new Error(\"somethign else\");\n}\n",
   ],
   names: [],
-  mappings: {
-    "lines": [
-      // third.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 3,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 4,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 5,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 0,
-          "srcLine": 6,
-          "srcCol": 0,
-        },
-      ],
-      // fourth.js mappings
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 0,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 1,
-          "srcCol": 0,
-        },
-      ],
-      [
-        {
-          "fieldCount": 4,
-          "col": 0,
-          "src": 1,
-          "srcLine": 2,
-          "srcCol": 0,
-        },
-      ],
+  mappings: [
+    // third.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
     ],
-  },
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 3,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 4,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 5,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 0,
+        "srcLine": 6,
+        "srcCol": 0,
+      },
+    ],
+    // fourth.js mappings
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 0,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 1,
+        "srcCol": 0,
+      },
+    ],
+    [
+      {
+        "fieldCount": 4,
+        "col": 0,
+        "src": 1,
+        "srcLine": 2,
+        "srcCol": 0,
+      },
+    ],
+  ],
   file: "",
 };

--- a/src/tests/fixtures/map3-4.ts
+++ b/src/tests/fixtures/map3-4.ts
@@ -12,117 +12,97 @@ export default {
   mappings: {
     "lines": [
       // third.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 3,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 4,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 5,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 0,
-            "srcLine": 6,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 3,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 4,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 5,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 0,
+          "srcLine": 6,
+          "srcCol": 0,
+        },
+      ],
       // fourth.js mappings
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 0,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 1,
-            "srcCol": 0,
-          },
-        ],
-      },
-      {
-        "mappings": [
-          {
-            "fieldCount": 4,
-            "col": 0,
-            "src": 1,
-            "srcLine": 2,
-            "srcCol": 0,
-          },
-        ],
-      },
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 0,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 1,
+          "srcCol": 0,
+        },
+      ],
+      [
+        {
+          "fieldCount": 4,
+          "col": 0,
+          "src": 1,
+          "srcLine": 2,
+          "srcCol": 0,
+        },
+      ],
     ],
   },
   file: "",

--- a/src/tests/vlq-tests.ts
+++ b/src/tests/vlq-tests.ts
@@ -59,28 +59,26 @@ describe("test encode", function() {
 
     mappingsDecoder.decode(reader);
 
-    expect(decoder.mappings).to.deep.equal({
-      lines: [ [
-          { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
-          { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
-          { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
-          { fieldCount: 5, col: 197, src: 0, srcLine: 7,  srcCol: 29, name: 2 },
-          { fieldCount: 5, col: 199, src: 0, srcLine: 7,  srcCol: 33, name: 3 },
-          { fieldCount: 4, col: 202, src: 0, srcLine: 8,  srcCol: 0,  name: 0 },
-          { fieldCount: 5, col: 209, src: 0, srcLine: 8,  srcCol: 10, name: 1 },
-          { fieldCount: 4, col: 212, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 216, src: 0, srcLine: 9,  srcCol: 9,  name: 0 },
-          { fieldCount: 4, col: 225, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 231, src: 0, srcLine: 9,  srcCol: 26, name: 0 },
-          { fieldCount: 5, col: 235, src: 0, srcLine: 9,  srcCol: 30, name: 4 },
-          { fieldCount: 5, col: 238, src: 0, srcLine: 9,  srcCol: 37, name: 2 },
-          { fieldCount: 5, col: 240, src: 0, srcLine: 9,  srcCol: 41, name: 3 },
-          { fieldCount: 4, col: 242, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
-          { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
-      ] ],
-    });
+    expect(decoder.mappings).to.deep.equal([[
+      { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
+      { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
+      { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
+      { fieldCount: 5, col: 197, src: 0, srcLine: 7,  srcCol: 29, name: 2 },
+      { fieldCount: 5, col: 199, src: 0, srcLine: 7,  srcCol: 33, name: 3 },
+      { fieldCount: 4, col: 202, src: 0, srcLine: 8,  srcCol: 0,  name: 0 },
+      { fieldCount: 5, col: 209, src: 0, srcLine: 8,  srcCol: 10, name: 1 },
+      { fieldCount: 4, col: 212, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 216, src: 0, srcLine: 9,  srcCol: 9,  name: 0 },
+      { fieldCount: 4, col: 225, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 231, src: 0, srcLine: 9,  srcCol: 26, name: 0 },
+      { fieldCount: 5, col: 235, src: 0, srcLine: 9,  srcCol: 30, name: 4 },
+      { fieldCount: 5, col: 238, src: 0, srcLine: 9,  srcCol: 37, name: 2 },
+      { fieldCount: 5, col: 240, src: 0, srcLine: 9,  srcCol: 41, name: 3 },
+      { fieldCount: 4, col: 242, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
+      { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
+    ]]);
   });
 
   it("mappings decoder (another)", function() {
@@ -93,45 +91,43 @@ describe("test encode", function() {
 
     let mappings = decoder.mappings;
 
-    expect(mappings.lines.length, "mappings.lines.length").to.equal(25);
-    expect(mappings.lines[0].length).to.equal(1);
-    expect(mappings.lines[0][0], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 12, name: 0 });
+    expect(mappings.length, "mappings.length").to.equal(25);
+    expect(mappings[0].length).to.equal(1);
+    expect(mappings[0][0], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 12, name: 0 });
 
-    expect(mappings.lines[1].length).to.equal(0);
-    expect(mappings.lines[2].length).to.equal(8);
+    expect(mappings[1].length).to.equal(0);
+    expect(mappings[2].length).to.equal(8);
 
-    expect(mappings.lines[2][0], "AAArB").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: -9, src: 0, col:  0, name: 0 });
-    expect(mappings.lines[2][1], "WAAS").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol:  0, src: 0, col: 11, name: 0 });
-    expect(mappings.lines[2][2], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 23, name: 0 });
-    expect(mappings.lines[2][3], "CAAC").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 13, src: 0, col: 24, name: 0 });
-    expect(mappings.lines[2][4], "IAAI").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 17, src: 0, col: 28, name: 0 });
-    expect(mappings.lines[2][5], "EAAE").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 19, src: 0, col: 30, name: 0 });
+    expect(mappings[2][0], "AAArB").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: -9, src: 0, col:  0, name: 0 });
+    expect(mappings[2][1], "WAAS").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol:  0, src: 0, col: 11, name: 0 });
+    expect(mappings[2][2], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 23, name: 0 });
+    expect(mappings[2][3], "CAAC").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 13, src: 0, col: 24, name: 0 });
+    expect(mappings[2][4], "IAAI").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 17, src: 0, col: 28, name: 0 });
+    expect(mappings[2][5], "EAAE").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 19, src: 0, col: 30, name: 0 });
   });
 
   it("encoder", function() {
     // (lines + segemnts * 6) = byte_count
-    let decoded = {
-      lines: [ [
-          { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
-          { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
-          { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
-          { fieldCount: 5, col: 197, src: 0, srcLine: 7,  srcCol: 29, name: 2 },
-          { fieldCount: 5, col: 199, src: 0, srcLine: 7,  srcCol: 33, name: 3 },
-          { fieldCount: 4, col: 202, src: 0, srcLine: 8,  srcCol: 0,  name: 0 },
-          { fieldCount: 5, col: 209, src: 0, srcLine: 8,  srcCol: 10, name: 1 },
-          { fieldCount: 4, col: 212, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 216, src: 0, srcLine: 9,  srcCol: 9,  name: 0 },
-          { fieldCount: 4, col: 225, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 231, src: 0, srcLine: 9,  srcCol: 26, name: 0 },
-          { fieldCount: 5, col: 235, src: 0, srcLine: 9,  srcCol: 30, name: 4 },
-          { fieldCount: 5, col: 238, src: 0, srcLine: 9,  srcCol: 37, name: 2 },
-          { fieldCount: 5, col: 240, src: 0, srcLine: 9,  srcCol: 41, name: 3 },
-          { fieldCount: 4, col: 242, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
-          { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
-      ] ],
-    };
+    let decoded = [[
+      { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
+      { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
+      { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
+      { fieldCount: 5, col: 197, src: 0, srcLine: 7,  srcCol: 29, name: 2 },
+      { fieldCount: 5, col: 199, src: 0, srcLine: 7,  srcCol: 33, name: 3 },
+      { fieldCount: 4, col: 202, src: 0, srcLine: 8,  srcCol: 0,  name: 0 },
+      { fieldCount: 5, col: 209, src: 0, srcLine: 8,  srcCol: 10, name: 1 },
+      { fieldCount: 4, col: 212, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 216, src: 0, srcLine: 9,  srcCol: 9,  name: 0 },
+      { fieldCount: 4, col: 225, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 231, src: 0, srcLine: 9,  srcCol: 26, name: 0 },
+      { fieldCount: 5, col: 235, src: 0, srcLine: 9,  srcCol: 30, name: 4 },
+      { fieldCount: 5, col: 238, src: 0, srcLine: 9,  srcCol: 37, name: 2 },
+      { fieldCount: 5, col: 240, src: 0, srcLine: 9,  srcCol: 41, name: 3 },
+      { fieldCount: 4, col: 242, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
+      { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
+      { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
+    ]];
 
     // TODO: pretty sure we can do a Uint8Array here
     // let buffer = new Uint32Array(estimatedSize);

--- a/src/tests/vlq-tests.ts
+++ b/src/tests/vlq-tests.ts
@@ -60,8 +60,7 @@ describe("test encode", function() {
     mappingsDecoder.decode(reader);
 
     expect(decoder.mappings).to.deep.equal({
-      lines: [ {
-        mappings: [
+      lines: [ [
           { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
           { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
           { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
@@ -80,8 +79,7 @@ describe("test encode", function() {
           { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
           { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
           { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
-        ],
-      } ],
+      ] ],
     });
   });
 
@@ -96,25 +94,24 @@ describe("test encode", function() {
     let mappings = decoder.mappings;
 
     expect(mappings.lines.length, "mappings.lines.length").to.equal(25);
-    expect(mappings.lines[0].mappings.length).to.equal(1);
-    expect(mappings.lines[0].mappings[0], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 12, name: 0 });
+    expect(mappings.lines[0].length).to.equal(1);
+    expect(mappings.lines[0][0], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 12, name: 0 });
 
-    expect(mappings.lines[1].mappings.length).to.equal(0);
-    expect(mappings.lines[2].mappings.length).to.equal(8);
+    expect(mappings.lines[1].length).to.equal(0);
+    expect(mappings.lines[2].length).to.equal(8);
 
-    expect(mappings.lines[2].mappings[0], "AAArB").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: -9, src: 0, col:  0, name: 0 });
-    expect(mappings.lines[2].mappings[1], "WAAS").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol:  0, src: 0, col: 11, name: 0 });
-    expect(mappings.lines[2].mappings[2], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 23, name: 0 });
-    expect(mappings.lines[2].mappings[3], "CAAC").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 13, src: 0, col: 24, name: 0 });
-    expect(mappings.lines[2].mappings[4], "IAAI").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 17, src: 0, col: 28, name: 0 });
-    expect(mappings.lines[2].mappings[5], "EAAE").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 19, src: 0, col: 30, name: 0 });
+    expect(mappings.lines[2][0], "AAArB").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: -9, src: 0, col:  0, name: 0 });
+    expect(mappings.lines[2][1], "WAAS").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol:  0, src: 0, col: 11, name: 0 });
+    expect(mappings.lines[2][2], "YAAY").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 12, src: 0, col: 23, name: 0 });
+    expect(mappings.lines[2][3], "CAAC").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 13, src: 0, col: 24, name: 0 });
+    expect(mappings.lines[2][4], "IAAI").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 17, src: 0, col: 28, name: 0 });
+    expect(mappings.lines[2][5], "EAAE").to.deep.equal({ fieldCount: 4, srcLine: 0, srcCol: 19, src: 0, col: 30, name: 0 });
   });
 
   it("encoder", function() {
     // (lines + segemnts * 6) = byte_count
     let decoded = {
-      lines: [ {
-        mappings: [
+      lines: [ [
           { fieldCount: 4, col: 183, src: 0, srcLine: 7,  srcCol: 0,  name: 0 },
           { fieldCount: 5, col: 192, src: 0, srcLine: 7,  srcCol: 9,  name: 0 },
           { fieldCount: 5, col: 195, src: 0, srcLine: 7,  srcCol: 23, name: 1 },
@@ -132,8 +129,8 @@ describe("test encode", function() {
           { fieldCount: 4, col: 242, src: 0, srcLine: 9,  srcCol: 0,  name: 0 },
           { fieldCount: 4, col: 247, src: 0, srcLine: 10, srcCol: 9,  name: 0 },
           { fieldCount: 4, col: 261, src: 0, srcLine: 10, srcCol: 0,  name: 0 },
-          { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 } ],
-      } ],
+          { fieldCount: 4, col: 267, src: 0, srcLine: 10, srcCol: 31, name: 0 },
+      ] ],
     };
 
     // TODO: pretty sure we can do a Uint8Array here


### PR DESCRIPTION
This PR removes several seemingly unnecessary object allocations of the `lines` and `mappings` wrappers.

This is changing the public interface, but since we're not close to stable and I'm not aware of any serious users yet this should probably be fine.

/cc @stefanpenner @krisselden 
